### PR TITLE
[fix] seems like a typo

### DIFF
--- a/docs/zh_CN/source/contents/0600_user_defined.rst
+++ b/docs/zh_CN/source/contents/0600_user_defined.rst
@@ -251,7 +251,7 @@ HyperTS针对不同的模式内置了丰富的建模算法, 例如:
 
         def __init__(self, fit_kwargs, **kwargs):
             super(TransformerWrapper, self).__init__(fit_kwargs, **kwargs)
-            self.update_dl_kwargs()
+            self.update_fit_kwargs()
             self.model = Transformer(**self.init_kwargs)
 
 


### PR DESCRIPTION
Hi!

I try the user defined estimator in the documentation [0600_user_defined](https://github.com/DataCanvasIO/HyperTS/blob/main/docs/zh_CN/source/contents/0600_user_defined.rst#%E6%9E%84%E5%BB%BA%E7%AE%97%E6%B3%95%E4%BC%B0%E8%AE%A1%E5%99%A8).

But I got a probelm that the method `update_dl_kwargs` cannot be found in `TransformerWrapper`.

At the same time, I notice there is a similar function named `update_fit_kwargs` in  `hyperts/framework/wrappers/_base.py#233`.